### PR TITLE
[REFACTOR] CD 수정

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout
@@ -51,43 +51,16 @@ jobs:
 
   deploy:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
-      - name: Setup SSH
-        run: |
-          mkdir -p ~/.ssh
-          
-          echo "${{ secrets.DEV_BASTION_KEY }}" > ~/.ssh/bastion_key
-          chmod 600 ~/.ssh/bastion_key
-          
-          echo "${{ secrets.DEV_BATCH_EC2_KEY }}" > ~/.ssh/batch_key
-          chmod 600 ~/.ssh/batch_key
-          
-          cat >> ~/.ssh/config << 'EOF'
-          Host bastion
-            HostName ${{ secrets.DEV_BASTION_HOST }}
-            User ${{ secrets.DEV_BASTION_USER }}
-            IdentityFile ~/.ssh/bastion_key
-            StrictHostKeyChecking no
-          
-          Host batch-server
-            HostName ${{ secrets.DEV_BATCH_SERVER_IP }}
-            User ${{ secrets.DEV_BATCH_USER }}
-            IdentityFile ~/.ssh/batch_key
-            ProxyJump bastion
-            StrictHostKeyChecking no
-          EOF
-
       - name: Deploy to Batch server
         run: |
           echo "========================================="
           echo "🚀 Deploying to Dev Batch Server"
-          echo "Version: ${{ env.VERSION }}"
           echo "========================================="
           
-          ssh batch-server << 'ENDSSH'
-            echo "${{ secrets.DOCKERHUB_PASSWORD }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+          ${{ secrets.DEV_BATCH_SSH_COMMAND }} << 'ENDSSH'
             cd ~
             ./deploy.sh
           ENDSSH

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout
@@ -44,50 +44,23 @@ jobs:
 
       - name: Build and push
         run: |
-          docker buildx build -f Dockerfile-dev --platform linux/amd64 \
+          docker buildx build -f Dockerfile-prod --platform linux/amd64 \
             -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROD_DOCKERHUB_REPO }}:latest \
             -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROD_DOCKERHUB_REPO }}:${{ env.VERSION }} \
             --push .
 
   deploy:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
-      - name: Setup SSH
-        run: |
-          mkdir -p ~/.ssh
-          
-          echo "${{ secrets.PROD_BASTION_KEY }}" > ~/.ssh/bastion_key
-          chmod 600 ~/.ssh/bastion_key
-          
-          echo "${{ secrets.PROD_BATCH_EC2_KEY }}" > ~/.ssh/batch_key
-          chmod 600 ~/.ssh/batch_key
-          
-          cat >> ~/.ssh/config << 'EOF'
-          Host bastion
-            HostName ${{ secrets.PROD_BASTION_HOST }}
-            User ${{ secrets.PROD_BASTION_USER }}
-            IdentityFile ~/.ssh/bastion_key
-            StrictHostKeyChecking no
-          
-          Host batch-server
-            HostName ${{ secrets.PROD_BATCH_SERVER_IP }}
-            User ${{ secrets.PROD_BATCH_USER }}
-            IdentityFile ~/.ssh/batch_key
-            ProxyJump bastion
-            StrictHostKeyChecking no
-          EOF
-
       - name: Deploy to Batch server
         run: |
           echo "========================================="
           echo "🚀 Deploying to Prod Batch Server"
-          echo "Version: ${{ env.VERSION }}"
           echo "========================================="
           
-          ssh batch-server << 'ENDSSH'
-            echo "${{ secrets.DOCKERHUB_PASSWORD }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+          ${{ secrets.PROD_BATCH_SSH_COMMAND }} << 'ENDSSH'
             cd ~
             ./deploy.sh
           ENDSSH


### PR DESCRIPTION
## #️⃣ Issue Number
#4 

## 📝 요약(Summary)
- Self-hosted Runner를 Bastion Host에 설치하여 Private Subnet의 Batch 서버 자동 배포 구현
- GitHub-hosted Runner는 VPC 외부에 있어 Private Subnet 접근 불가능한 문제 해결
- Bastion을 Runner로 사용하여 VPC 내부에서 Batch 서버에 직접 SSH 접근 가능
- 보안 강화: Bastion SSH는 개발자 IP만 허용, Runner는 내부에서 실행

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
### 아키텍처
- GitHub Actions → Bastion(Self-hosted Runner) → Batch 서버(Private Subnet)
- Bastion에서 빌드 및 Docker 이미지 생성 후 Docker Hub에 Push
- Batch 서버는 이미지를 Pull하여 컨테이너로 실행

### Self-hosted Runner를 선택한 이유
1. Private Subnet 접근: GitHub-hosted Runner는 VPC 외부에 있어 Private Subnet 직접 접근 불가
2. 고정 IP: Self-hosted는 고정 IP를 가지므로 보안 그룹 관리 용이
3. 보안: GitHub-hosted 사용 시 수백 개의 GitHub IP 범위를 보안 그룹에 추가해야 하는 위험 회피