### PR TITLE
[REFACTOR] S3 디렉토리명 변경

### DIFF
--- a/src/main/java/tetoandeggens/seeyouagainbatch/job/s3profileupload/processor/S3ProfileUploadProcessor.java
+++ b/src/main/java/tetoandeggens/seeyouagainbatch/job/s3profileupload/processor/S3ProfileUploadProcessor.java
@@ -28,6 +28,7 @@ import tetoandeggens.seeyouagainbatch.job.s3profileupload.exception.ImageNotFoun
 public class S3ProfileUploadProcessor implements ItemProcessor<AnimalProfile, AnimalS3Profile> {
 
 	private static final String S3_KEY_PREFIX = "animal-profiles/";
+	private static final String PUBLIC_DATA_PREFIX = "public-data/";
 	private static final String FILE_EXTENSION = ".webp";
 	private static final String UNDERSCORE = "_";
 	private static final String LEFT_BRACKET = "[";
@@ -107,7 +108,7 @@ public class S3ProfileUploadProcessor implements ItemProcessor<AnimalProfile, An
 
 	private String generateS3Key(Long animalProfileId) {
 		String uuid = UUID.randomUUID().toString();
-		return S3_KEY_PREFIX + animalProfileId + UNDERSCORE + uuid + FILE_EXTENSION;
+		return S3_KEY_PREFIX + PUBLIC_DATA_PREFIX + animalProfileId + UNDERSCORE + uuid + FILE_EXTENSION;
 	}
 
 	private HttpResponse<InputStream> downloadImageAsStream(String imageUrl) throws


### PR DESCRIPTION
## #️⃣ Issue Number

#14 

## 📝 요약(Summary)

- 실종/목격 게시글 작성 시 이미지 첨부 할 때와 공공데이터 포털의 이미지를 s3에 업로드 할 때를 구분하기 위해, 디렉토리를 상세화

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
